### PR TITLE
fix: make cpu and ram nullable in APIApplicationStatusAll payload

### DIFF
--- a/payloads/v2/status.ts
+++ b/payloads/v2/status.ts
@@ -42,8 +42,8 @@ export type APIApplicationStatusPayload = APIPayload<APIApplicationStatus>;
  */
 export interface APIApplicationStatusAll {
 	id: ApplicationId;
-	cpu: string;
-	ram: string;
+	cpu?: string;
+	ram?: string;
 	running: boolean;
 }
 


### PR DESCRIPTION
Fix the response payload for the request at [/app/status-all](https://docs.squarecloud.app/api-reference/endpoint/apps/status-all).

When the application is running, it contains the ``ram`` and ``cpu`` responses, but when it is not running, it does not. 
```json
{
  "status": "success",
  "response": [
    {
      "id": "-",
      "running": false
    },
    {
      "id": "-",
      "running": true,
      "cpu": "0.00%",
      "ram": "39.78MB"
    }
  ]
}
```